### PR TITLE
[Salvo] install lcov via install_deps.sh

### DIFF
--- a/salvo/install_deps.sh
+++ b/salvo/install_deps.sh
@@ -17,7 +17,8 @@ fi
   docker.io \
   python3-pytest \
   python3-docker \
-  openjdk-11-jdk
+  openjdk-11-jdk \
+  lcov
 
 
 pip3 install --upgrade --user pip

--- a/salvo/install_deps.sh
+++ b/salvo/install_deps.sh
@@ -14,10 +14,12 @@ fi
 
 /usr/bin/apt update
 /usr/bin/apt -y install \
+  containerd \
   docker.io \
   python3-pytest \
   python3-docker \
   openjdk-11-jdk \
+  python-apt \
   lcov
 
 

--- a/salvo/requirements.txt
+++ b/salvo/requirements.txt
@@ -21,7 +21,6 @@ py==1.5.2
 pybind11==2.6.1
 pygobject==3.26.1
 pytest==3.3.2
-python-apt==1.6.5+ubuntu0.3
 python-dateutil==2.8.1
 pytype==2020.11.12
 PyYAML==5.1


### PR DESCRIPTION
This small PR updates `salvo/install_deps.sh`.

`containerd` is needed before installing `docker.io`
`lcov` is needed to run `./tools/coverage.sh`
`python-apt` has to be installed via `apt install` and not via `pip install -r requirements.txt`

Signed-off-by: Sunil Narasimhamurthy <sunnrs@amazon.com>

